### PR TITLE
Summer of making as draft breaks build

### DIFF
--- a/content/blog/2024/summer-of-making/index.md
+++ b/content/blog/2024/summer-of-making/index.md
@@ -5,7 +5,7 @@ tags:
     - Events
     - Making
     - Programme
-draft: true
+draft: false
 author: Kian Ryan
 author_email: kian@orangetentacle.co.uk
 listing_image: images/summer_of_making.jpg


### PR DESCRIPTION
Posts marked draft will work locally, but break production build page links.

Mark Summer of Making page as NOT draft, fixing page links.