### PR TITLE
Update Social media icons and opening times

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -122,6 +122,6 @@ url = "https://github.com/leigh-hackspace"
 icon = "fab fa-github-alt"
 
 [[params.social_links]]
-name = "discourse"
-url = "https://discourse.leighhack.org"
-icon = "fab fa-discourse"
+name = "bluesky"
+url = "https://bsky.app/profile/leighhackspace.bsky.social"
+icon = "fab fa-bluesky"

--- a/content/_index.md
+++ b/content/_index.md
@@ -13,7 +13,7 @@ hero_image: long_logo_solo_whitebg.svg
 | --------- | ------------- |
 | Monday    | 18:30 - 21:00 |
 | Tuesday   | 14:00 - 21:00 |
-| Wednesday | 14:00 - 21:00 |
+| Wednesday | 18:30 - 21:00 |
 | Thursday  | Closed        |
 | Friday    | Closed        |
 | Saturday  | 12:00 - 17:00 |


### PR DESCRIPTION
Replace Discourse social media with Bluesky, update Wednesday opening times